### PR TITLE
Optimize shuffle fetch of contiguous

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -66,6 +66,7 @@ Since I'm always working on some side-projects, I decided to document the progre
 
 - Ep.17: https://github.com/JoaquimLey/transport-eta/pull/81
 
+- Ep.17: https://github.com/JoaquimLey/transport-eta/pull/83
 
 ## About the author
 Hi, my name is  **Joaquim Ley**, I'm a Software Engineer (Android).

--- a/transport-eta-android/build.gradle
+++ b/transport-eta-android/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    apply from: './versions.gradle'
+    apply from: './dependencies.gradle'
     addRepos(repositories)
     dependencies {
         classpath deps.kotlin.plugin

--- a/transport-eta-android/dependencies.gradle
+++ b/transport-eta-android/dependencies.gradle
@@ -61,7 +61,7 @@ versions.mockito = "2.19.1"
 versions.mockito_kotlin = "2.0.0-RC1"
 versions.atsl_rules = "1.0.1"
 versions.atsl_runner = "1.0.2"
-versions.robolectric = "3.8" // "4.0-beta-2-SNAPSHOT" // "3.8"
+versions.robolectric = "4.0-beta-2-SNAPSHOT" // "3.8"
 versions.dexmaker_linkedin = "2.19.0"
 versions.dexmaker_linkedin_inline = "2.19.0"
 
@@ -207,7 +207,10 @@ ext.app_version = app_version
 static def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
+
+    // For Kotlinx serialization
     handler.maven { url "https://kotlin.bintray.com/kotlinx" }
+    // For Robolectric 4.0-snapshot
     handler.maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 }
 ext.addRepos = this.&addRepos


### PR DESCRIPTION
* Scaffold sharedpreferences module

- Attach to store implemetnation
- Mock data currently being returned

Some housekeeping.

* Small configurations for CI

Still not working, wanted to make mock work with debug but variants still compain.

* Test removing ViewModelModule

* Ci why you no work?

* Fix lints on CI

* Working stuff for CI

* housekeeping mobile-ui/build.gradle

Had to make some changtes while debuging CI fails. This change still makes sense IMO.

#69

* Rename data package to include project name
#69

* Remove unecessary .gitignore from other packages

Maintenece commit, not really related to this branch feature.

* Manifest cleanup and format

* Scaffold stuff for stream episode 17

Some basic ideas just so I know what I'm supposed to continue, a lot of TODOs
so lint warns me.

For #17
Ref #69

* Housekeeping from previous commit

* Fix typo in readme

Changed the copy on the stream log section

* Include kotlinx.serialization experimental library for sharedPrefs

This will be included in the stblib from Kotlin 1.3.

#17, #69

* Make SharedPrefTransport model @kotlinx.serialization.Serializable

Also, fixes and issue where the String was default to  which made the serialization fail:
 - https://github.com/Kotlin/kotlinx.serialization/issues/115

#17, #69

* Implement initial SharedPref slot save logic

#17, #69

* Add stream ep to README, ignore failing test on shared pref

#17, #69